### PR TITLE
Add ModMenu client badge and issue tracker link

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,8 @@
   ],
   "contact": {
     "homepage": "https://amerebagatelle.github.io/",
-    "sources": "https://github.com/AMereBagatelle/AFKPeace"
+    "sources": "https://github.com/AMereBagatelle/AFKPeace",
+    "issues": "https://github.com/AMereBagatelle/AFKPeace/issues"
   },
   "license": "MIT",
   "icon": "assets/afkpeace/icon.png",
@@ -21,6 +22,9 @@
     "cotton-client-commands": [
       "amerebagatelle.github.io.afkpeace.commands.ConfigCommand"
     ]
+  },
+    "custom": {
+    "modmenu:clientsideOnly": true
   },
   "mixins": [
     "afkpeace.mixins.json"


### PR DESCRIPTION
The mod [ModMenu](https://www.curseforge.com/minecraft/mc-mods/modmenu) has the option to display a **"Client"** badge besides the mod name. However, it needs to be specified in the `fabric.mod.json`.

This pull request add support for that.
Besides that I also included the issue tracker link, it is also displayed in ModMenu.

ModMenu is pretty established in the community now, and this is only a small quality of life feature.

![afkpeace_modmenu](https://user-images.githubusercontent.com/42546705/87550450-540dfa00-c6af-11ea-9903-d7ad0d7667e7.png)


