### PR TITLE
Fix Modrinth download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AFKPeace
 
 [![Discord Shield](https://discordapp.com/api/guilds/756203400089305128/widget.png?style=shield)](https://discord.gg/quvzkaV)
-[![Modrinth Shield](https://img.shields.io/badge/dynamic/json?color=blue&label=Modrinth&query=downloads&url=https%3A%2F%2Fapi.modrinth.com%2Fapi%2Fv1%2Fmod%2F65jTHvHz)](https://modrinth.com/mod/afkpeace)
+[![Modrinth Shield](https://img.shields.io/modrinth/dt/afkpeace?color=blue&label=Modrinth)](https://modrinth.com/mod/afkpeace)
 
 The mod to give you peace of mind while AFK!
 


### PR DESCRIPTION
v1 of Modrinth's API has been deprecated since January 2022 and is scheduled to begin breaking in February, with a complete breakage being done by March. This pull request has been created as a courtesy to update it to use the dedicated shields.io badge rather than manually constructing the API request.

After merging this PR, please also update any usages on other pages, for example a CurseForge and/or Modrinth project description, and also cherry-pick/copy these changes to any other branches you might have.